### PR TITLE
feat: Add microseconds and nanoseconds

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,8 @@ const keyList = {
   m: "minutes",
   s: "seconds",
   ms: "milliseconds",
+  ns: "nanoseconds",
+  us: "microseconds",
 };
 
 /**
@@ -27,6 +29,8 @@ const keyList = {
  * @property {Number} m - Number of minutes held by duration
  * @property {Number} s - Number of seconds held by duration
  * @property {Number} ms - Number of milliseconds held by duration
+ * @property {Number} us - Number of microseconds held by duration
+ * @property {Number} ns - Number of nanoseconds held by duration
  */
 
 /**
@@ -48,6 +52,8 @@ class Duration {
     this.m = Math.trunc(timestamp / 60000) % 60;
     this.s = Math.trunc(timestamp / 1000) % 60;
     this.ms = Math.trunc(timestamp) % 1000;
+    this.us = Math.trunc(timestamp * 1000) % 1000;
+    this.ns = Math.trunc(timestamp * 1000000) % 1000;
   }
   /**
    * Data in the class mapped into an Array with properties "type" and "value"
@@ -60,7 +66,15 @@ class Duration {
       { type: "m", value: this.m },
       { type: "s", value: this.s },
       { type: "ms", value: this.ms },
+      { type: "ns", value: this.ns },
+      { type: "µs", value: this.µs },
     ];
+  }
+  /**
+   * Alt way to get microseconds
+   */
+  get µs() {
+    return this.µs;
   }
   /**
    * Data in the class mapped as a JavaScript Object.
@@ -69,11 +83,10 @@ class Duration {
   get json() {
     return this.array.reduce(
       (acc, stuff) => ((acc[stuff.type] = stuff.value), acc),
-      {}
+      {},
     );
   }
   /**
-   *
    * @param {string[]} values - The values required to display
    * @param {boolean} shortandsweet - If response should be a short string.
    * @returns {string} formatted string - The formatted string result
@@ -84,10 +97,13 @@ class Duration {
         !shortandsweet ||
         typeof shortandsweet !== "boolean" ||
         shortandsweet == false
-      )
-        return `${this.array
-          .map((x) => `${x.value} ${keyList[x.type]}`)
-          .join(", ")}`;
+      ) {
+        return `${
+          this.array
+            .map((x) => `${x.value} ${keyList[x.type]}`)
+            .join(", ")
+        }`;
+      }
       return `${this.array.map((x) => `${x.value}${x.type}`).join(" ")}`;
     }
     if (values.length > 0) {
@@ -95,19 +111,26 @@ class Duration {
         !shortandsweet ||
         typeof shortandsweet !== "boolean" ||
         shortandsweet == false
-      )
-        return `${this.array
+      ) {
+        return `${
+          this.array
+            .filter((x) => values.includes(x.type))
+            .map((x) => `${x.value} ${keyList[x.type]}`)
+            .join(", ")
+        }`;
+      }
+      return `${
+        this.array
           .filter((x) => values.includes(x.type))
-          .map((x) => `${x.value} ${keyList[x.type]}`)
-          .join(", ")}`;
-      return `${this.array
-        .filter((x) => values.includes(x.type))
-        .map((x) => `${x.value}${x.type}`)
-        .join(" ")}`;
+          .map((x) => `${x.value}${x.type}`)
+          .join(" ")
+      }`;
     }
-    return `${this.array
-      .map((x) => `${x.value} ${keyList[x.type]}`)
-      .join(", ")}`;
+    return `${
+      this.array
+        .map((x) => `${x.value} ${keyList[x.type]}`)
+        .join(", ")
+    }`;
   }
   /**
    * Get a duration formatted using colons (:)
@@ -115,14 +138,15 @@ class Duration {
    * @param {string} toT - Unit to display upto
    * @returns {string} Formatted string
    */
-  getFormattedDuration(fromT = "d", toT = "ms") {
+  getFormattedDuration(fromT = "d", toT = "µs") {
     if (
       typeof fromT !== "string" ||
       typeof toT !== "string" ||
       !keyList.hasOwnProperty(fromT.toLowerCase()) ||
       !keyList.hasOwnProperty(toT.toLowerCase())
-    )
+    ) {
       return this.getSimpleFormattedDuration();
+    }
     const durations = [];
     const next =
       this.array[this.array.findIndex((x) => x.type === toT.toLowerCase()) + 1];
@@ -152,12 +176,11 @@ class Duration {
    * @returns {<Duration>}
    */
   reload() {
-    const ts =
-      this.d * 8.64e7 +
+    const ts = this.d * 8.64e7 +
       this.h * 3600000 +
       this.m * 60000 +
       this.s * 1000 +
-      this.ms;
+      this.ms + (this.us / 1000) + (this.ns / 1000000);
     if (ts === this.raw) return this;
     const newDuration = new Duration(ts);
     this.d = newDuration.d;
@@ -165,6 +188,8 @@ class Duration {
     this.m = newDuration.m;
     this.s = newDuration.s;
     this.ms = newDuration.ms;
+    this.ns = newDuration.ns;
+    this.us = newDuration.us;
     this.raw = newDuration.raw;
     return this;
   }
@@ -175,16 +200,20 @@ class Duration {
    * @returns {<Duration>}
    */
   static fromString(str, doNotParse = false) {
-    const { d, h, m, s, ms } = Duration.readString(str);
-    const ts = d * 8.64e7 + h * 3600000 + m * 60000 + s * 1000 + ms;
+    const { d, h, m, s, ms, ns, us } = Duration.readString(str);
+    const ts = d * 8.64e7 + h * 3600000 + m * 60000 + s * 1000 + ms +
+      (us / 1000) +
+      (ns / 1000000);
 
     const newDuration = new Duration(ts);
     if (doNotParse) {
-      newDuration.days = days;
-      newDuration.hours = hours;
-      newDuration.minutes = minutes;
-      newDuration.seconds = seconds;
-      newDuration.milliseconds = milliseconds;
+      newDuration.d = d;
+      newDuration.h = h;
+      newDuration.m = m;
+      newDuration.s = s;
+      newDuration.ms = ms;
+      newDuration.ns = ns;
+      newDuration.us = us;
     }
     return newDuration;
   }
@@ -202,27 +231,39 @@ class Duration {
    */
   static readString(str) {
     str = str.replace(/\s\s/g, "");
-    const days =
-      matchReg(str, "d") || matchReg(str, "days") || matchReg(str, "day");
-    const hours =
-      matchReg(str, "h") || matchReg(str, "hours") || matchReg(str, "hour");
-    const minutes =
-      matchReg(str, "m") ||
+    const days = matchReg(str, "d") || matchReg(str, "days") ||
+      matchReg(str, "day");
+    const hours = matchReg(str, "h") || matchReg(str, "hours") ||
+      matchReg(str, "hour");
+    const minutes = matchReg(str, "m") ||
       matchReg(str, "min") ||
       matchReg(str, "minute") ||
       matchReg(str, "mins") ||
       matchReg(str, "minutes");
-    const seconds =
-      matchReg(str, "s") ||
+    const seconds = matchReg(str, "s") ||
       matchReg(str, "sec") ||
       matchReg(str, "second") ||
       matchReg(str, "secs") ||
       matchReg(str, "seconds");
-    const milliseconds =
-      matchReg(str, "ms") ||
+    const milliseconds = matchReg(str, "ms") ||
       matchReg(str, "millisecond") ||
       matchReg(str, "milliseconds");
-    return { d: days, h: hours, m: minutes, s: seconds, ms: milliseconds };
+    const nanoseconds = matchReg(str, "ns") ||
+      matchReg(str, "nanosecond") ||
+      matchReg(str, "nanoseconds");
+    const microseconds = matchReg(str, "µs") ||
+      matchReg(str, "microsecond") ||
+      matchReg(str, "microseconds");
+    matchReg(str, "us");
+    return {
+      d: days,
+      h: hours,
+      m: minutes,
+      s: seconds,
+      ms: milliseconds,
+      ns: nanoseconds,
+      us: microseconds,
+    };
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@retraigo/duration.js",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "type": "module",
   "description": "Get the formatted time duration",
   "main": "index.js",

--- a/test.js
+++ b/test.js
@@ -16,7 +16,7 @@ console.log(new Duration(245074).array);
 */
 // console.log(Duration.fromString("5 m s 54h 5d 44 s").stringify([], true))
 
-const d = new Duration(6000);
+const d = new Duration(6000.4353262);
 d.m += 70
 console.log(d) // Only d.m changes. d.h remains the same
 d.reload()


### PR DESCRIPTION
- Added microseconds (us) and nanoseconds (ns) as keys.
- Microseconds are referred with `us` instead of `µs` for ease of use. However, a getter for `µs` exists.
- Fixed the `fromString` method.