### PR TITLE
fix: remove condition for time

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,3 +149,6 @@ new Duration(245074).array;
 */
 ```
 
+
+## Support
+Join our Discord server [here](https://discord.gg/Ess9VJKYEZ)

--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ class Duration {
    * @returns {<Duration>}
    */
   constructor(timestamp = Duration.getCurrentDuration()) {
-    if (timestamp < 1) timestamp = 0; // Prevent negative time
+    if (timestamp < 0) timestamp = 0; // Prevent negative time
     this.raw = timestamp;
     this.d = Math.trunc(timestamp / 86400000);
     this.h = Math.trunc(timestamp / 3600000) % 24;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@retraigo/duration.js",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "type": "module",
   "description": "Get the formatted time duration",
   "main": "index.js",


### PR DESCRIPTION
Upto v2.3.0, all code was tested using `Date.now()` and duration was guaranteed to be either 0ms or >= 1ms.

However, when testing with `performance.now()`, I realized that having the total time less than 1ms causes the duration to get counted as 0.

I removed that dumb condition.