### PR TITLE
Remove `Object.hasOwn` and fallback

### DIFF
--- a/mod.js
+++ b/mod.js
@@ -103,7 +103,7 @@ class Duration {
         ).join(", ")}`;
     }
     getFormattedDuration(fromT = "d", toT = "ns") {
-        if (typeof fromT !== "string" || typeof toT !== "string" || !Object.hasOwn(keyList, fromT.toLowerCase()) || !Object.hasOwn(keyList, toT.toLowerCase())) {
+        if (typeof fromT !== "string" || typeof toT !== "string" || !Object.prototype.hasOwnProperty.call(keyList, fromT.toLowerCase()) || !Object.prototype.hasOwnProperty.call(keyList, toT.toLowerCase())) {
             return this.getSimpleFormattedDuration();
         }
         const durations = [];

--- a/mod.ts
+++ b/mod.ts
@@ -183,8 +183,8 @@ export class Duration {
     if (
       typeof fromT !== "string" ||
       typeof toT !== "string" ||
-      !Object.hasOwn(keyList, fromT.toLowerCase()) ||
-      !Object.hasOwn(keyList, toT.toLowerCase())
+      !Object.prototype.hasOwnProperty.call(keyList, fromT.toLowerCase()) ||
+      !Object.prototype.hasOwnProperty.call(keyList, toT.toLowerCase())
     ) {
       return this.getSimpleFormattedDuration();
     }

--- a/test.js
+++ b/test.js
@@ -1,0 +1,27 @@
+import {Duration} from "./mod.ts";
+
+/*
+const dur = new Duration(177013); // A random duration
+
+console.log(dur);
+console.log(new Duration(261174).toString());
+
+console.log(new Duration(165684).stringify());
+console.log(new Duration(165684).stringify(["s", "h"]));
+
+console.log(new Duration(114750).json);
+
+console.log(new Duration(245074).array);
+
+*/
+
+console.log(Duration.fromString("5 m s 54h 5d 44 s 34µs;").getFormattedDuration('h', 'ns'));
+
+/*
+const d = new Duration(6000.4353262);
+console.log(d.µs)
+d.m += 70;
+console.log(d); // Only d.m changes. d.h remains the same
+d.reload();
+console.log(d); // d.m turns into 10 and d.h turns into 1
+*/


### PR DESCRIPTION
**Describe your PR:**
I had previously used `Object.hasOwn` which is apparently not supported in Node < 16x so I'm falling back to `Object.hasOwnProperty` till 16x becomes more used or something.
