### PR TITLE
Patch 3.1.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .pnpm-debug.log
 dumpster.js
+testing/test.js

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 ## Documentation
 Check out [Neko Of The Abyss](https://docs.nekooftheabyss.moe) for documentation.
 
+Duration follows the `performance.now()` format, so microseconds and nanoseconds go after the decimal point.
+
 ## Installation
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ new Duration(261174).toString();
 #### stringify([values] [,short])
 
 `stringify()` returns a formatted string of the duration object. It has two optional parameters.
-`values` - An array of values to include. Should be one of `['d', 'h', 'm', 's', 'ms']`. Defaults to the array I mentioned a few words ago.
+`values` - An array of values to include. Should be one of `['d', 'h', 'm', 's', 'ms']`. Defaults to the array I mentioned a few words ago. Leave an empty array (TS) or null (JS) if you wanna skip this.
 `short` - `true` if the function should return letters instead of words (I suck at explaining). Defaults to false.
 
 ```js
@@ -108,10 +108,14 @@ new Duration(165684).getFormattedDuration("s", "h");
 // `45:684`
 // ignores the `to` parameter if it is larger than the `from` parameter
 ```
+**NOTE: `getFormattedDuration()` will be deprecated soon.`**
+
 
 #### getSimpleFormattedDuration()
 
 `getSimpleFormattedDuration()` returns a formatted string of the duration object in the `d:h:m:s:ms` format.
+
+**NOTE: `getSimpleFormattedDuration()` is deprecated. Please use `Duration#toString()`**
 
 ```js
 new Duration(165684).getSimpleFormattedDuration();

--- a/mod.ts
+++ b/mod.ts
@@ -86,6 +86,7 @@ export class Duration {
    */
   constructor(timestamp: number = Duration.getCurrentDuration()) {
     if (timestamp < 0) timestamp = 0; // Prevent negative time
+    timestamp = Number(timestamp);
     this.raw = timestamp;
     this.d = Math.trunc(timestamp / 86400000);
     this.h = Math.trunc(timestamp / 3600000) % 24;
@@ -317,9 +318,12 @@ export class Duration {
     ) {
       return this.getSimpleFormattedDuration();
     }
-    const durations = this.getFormattedDurationArray()
-    const listOfKeys = Object.keys(keyList)
-    return durations.slice(listOfKeys.indexOf(fromT), listOfKeys.indexOf(toT) + 1).join(":");
+    const durations = this.getFormattedDurationArray();
+    const listOfKeys = Object.keys(keyList);
+    return durations.slice(
+      listOfKeys.indexOf(fromT),
+      listOfKeys.indexOf(toT) + 1,
+    ).join(":");
   }
   /**
    * Get a simple formatted duration in the form dd:hh:mm:ss:ms
@@ -329,7 +333,11 @@ export class Duration {
     return `${this.getFormattedDurationArray().join(":")}`;
   }
   getFormattedDurationArray(): string[] {
-    return this.array.map((x) => ["ms", "us", "ns"].includes(x.type) ? addZero(x.value, 3) : addZero(x.value, 2))
+    return this.array.map((x) =>
+      ["ms", "us", "ns"].includes(x.type)
+        ? addZero(x.value, 3)
+        : addZero(x.value, 2)
+    );
   }
   /**
    * Extra filler function that returns the class data in a single short string.

--- a/mod.ts
+++ b/mod.ts
@@ -192,6 +192,67 @@ export class Duration {
   }
 
   /**
+   * Get a duration formatted using colons (:).
+   * @param {string} fromT - Unit to display from.
+   * @param {string} toT - Unit to display upto.
+   * @returns {string} Formatted string.
+   */
+  getFormattedDuration(
+    fromT: DurationKeys = "d",
+    toT: DurationKeys = "ns",
+  ): string {
+    if (
+      typeof fromT !== "string" ||
+      typeof toT !== "string" ||
+      !Object.prototype.hasOwnProperty.call(keyList, fromT.toLowerCase()) ||
+      !Object.prototype.hasOwnProperty.call(keyList, toT.toLowerCase())
+    ) {
+      return this.getSimpleFormattedDuration();
+    }
+    const durations = this.getFormattedDurationArray();
+    const listOfKeys = Object.keys(keyList);
+    return durations.slice(
+      listOfKeys.indexOf(fromT),
+      listOfKeys.indexOf(toT) + 1,
+    ).join(":");
+  }
+  /**
+   * Get a simple formatted duration in the form dd:hh:mm:ss:ms (Deprecated. Use Duration#toString())
+   * @returns {string} Formatted string
+   */
+  getSimpleFormattedDuration(): string {
+    return this.toString();
+  }
+  getFormattedDurationArray(): string[] {
+    return this.array.map((x) =>
+      ["ms", "us", "ns"].includes(x.type)
+        ? addZero(x.value, 3)
+        : addZero(x.value, 2)
+    );
+  }
+  /**
+   * Update data to match any modification to values.
+   * @returns {<Duration>}
+   */
+  reload(): Duration {
+    const ts = this.d * 8.64e7 +
+      this.h * 3600000 +
+      this.m * 60000 +
+      this.s * 1000 +
+      this.ms + (this.us / 1000) + (this.ns / 1000000);
+    if (ts === this.raw) return this;
+    const newDuration = new Duration(ts);
+    this.d = newDuration.d;
+    this.h = newDuration.h;
+    this.m = newDuration.m;
+    this.s = newDuration.s;
+    this.ms = newDuration.ms;
+    this.ns = newDuration.ns;
+    this.us = newDuration.us;
+    this.raw = newDuration.raw;
+    return this;
+  }
+  /**
    * Set days of the duration.
    * @param {number} n - Number of days to set.
    * @returns {Duration} The updated duration.
@@ -301,50 +362,18 @@ export class Duration {
     }`;
   }
   /**
-   * Get a duration formatted using colons (:).
-   * @param {string} fromT - Unit to display from.
-   * @param {string} toT - Unit to display upto.
-   * @returns {string} Formatted string.
-   */
-  getFormattedDuration(
-    fromT: DurationKeys = "d",
-    toT: DurationKeys = "ns",
-  ): string {
-    if (
-      typeof fromT !== "string" ||
-      typeof toT !== "string" ||
-      !Object.prototype.hasOwnProperty.call(keyList, fromT.toLowerCase()) ||
-      !Object.prototype.hasOwnProperty.call(keyList, toT.toLowerCase())
-    ) {
-      return this.getSimpleFormattedDuration();
-    }
-    const durations = this.getFormattedDurationArray();
-    const listOfKeys = Object.keys(keyList);
-    return durations.slice(
-      listOfKeys.indexOf(fromT),
-      listOfKeys.indexOf(toT) + 1,
-    ).join(":");
-  }
-  /**
    * Get a simple formatted duration in the form dd:hh:mm:ss:ms
    * @returns {string} Formatted string
    */
-  getSimpleFormattedDuration(): string {
+  toString(): string {
     return `${this.getFormattedDurationArray().join(":")}`;
   }
-  getFormattedDurationArray(): string[] {
-    return this.array.map((x) =>
-      ["ms", "us", "ns"].includes(x.type)
-        ? addZero(x.value, 3)
-        : addZero(x.value, 2)
-    );
-  }
   /**
-   * Extra filler function that returns the class data in a single short string.
-   * @returns {string} Dumb string
+   * Convert the Duration into a plain object.
+   * @returns {DurationObj} Duration object
    */
-  toString(): string {
-    return `[Duration ${this.stringify(["d", "h", "m", "s"], true)}]`;
+  toJSON(): DurationObj {
+    return this.json;
   }
   /**
    * Just the valueOf method.
@@ -352,28 +381,6 @@ export class Duration {
    */
   valueOf(): number {
     return this.raw;
-  }
-  /**
-   * Update data to match any modification to values.
-   * @returns {<Duration>}
-   */
-  reload(): Duration {
-    const ts = this.d * 8.64e7 +
-      this.h * 3600000 +
-      this.m * 60000 +
-      this.s * 1000 +
-      this.ms + (this.us / 1000) + (this.ns / 1000000);
-    if (ts === this.raw) return this;
-    const newDuration = new Duration(ts);
-    this.d = newDuration.d;
-    this.h = newDuration.h;
-    this.m = newDuration.m;
-    this.s = newDuration.s;
-    this.ms = newDuration.ms;
-    this.ns = newDuration.ns;
-    this.us = newDuration.us;
-    this.raw = newDuration.raw;
-    return this;
   }
   /**
    * Get the duration between two timestamps or two other durations.

--- a/mod.ts
+++ b/mod.ts
@@ -419,10 +419,8 @@ export class Duration {
    * @returns {<Duration>}
    */
   static fromString(str: string, doNotParse = false): Duration {
-    const { d, h, m, s, ms, ns, us } = Duration.readString(str);
-    const ts = d * 8.64e7 + h * 3600000 + m * 60000 + s * 1000 + ms +
-      (us / 1000) +
-      (ns / 1000000);
+    const { raw, d, h, m, s, ms, ns, us } = Duration.readString(str);
+    const ts = raw;
 
     const newDuration = new Duration(ts);
     if (doNotParse) {
@@ -448,7 +446,7 @@ export class Duration {
    * @param {string} str - The string to read
    * @returns {DurationObj} obj - Object with days, hours, mins, seconds and milliseconds
    */
-  static readString(str: string) {
+  static readString(str: string): DurationObj {
     str = str.replace(/\s\s/g, "");
     const days = matchReg(str, "d") || matchReg(str, "days") ||
       matchReg(str, "day");
@@ -475,6 +473,10 @@ export class Duration {
       matchReg(str, "microseconds");
     matchReg(str, "us");
     return {
+      raw: days * 8.64e7 + hours * 3600000 + minutes * 60000 + seconds * 1000 +
+        milliseconds +
+        (microseconds / 1000) +
+        (nanoseconds / 1000000),
       d: days,
       h: hours,
       m: minutes,
@@ -483,6 +485,17 @@ export class Duration {
       ns: nanoseconds,
       us: microseconds,
     };
+  }
+  /**
+   * Get duration since a moment in time.
+   * @param {Date|number} when
+   * @returns {Duration} Duration
+   */
+  static since(when: number | Date): Duration {
+    return Duration.between(
+      when instanceof Date ? when.getMilliseconds() : when,
+      null,
+    );
   }
 }
 

--- a/mod.ts
+++ b/mod.ts
@@ -106,7 +106,7 @@ export class Duration {
       { type: "m", value: this.m },
       { type: "s", value: this.s },
       { type: "ms", value: this.ms },
-      { type: "us", value: this.µs },
+      { type: "us", value: this.us },
       { type: "ns", value: this.ns },
     ];
   }
@@ -317,29 +317,19 @@ export class Duration {
     ) {
       return this.getSimpleFormattedDuration();
     }
-    const durations = [];
-    const nextIndex =
-      this.array.findIndex((x) => x.type === toT.toLowerCase()) + 1;
-    const next = this.array[nextIndex];
-    for (const obj of this.array) {
-      if (obj.type !== fromT.toLowerCase() && durations.length === 0) continue;
-      if (obj.type === next?.type) break;
-      durations.push(
-        ["ms", "us", "ns"].includes(obj.type)
-          ? addZero(obj.value, 3)
-          : obj.type === "d"
-          ? obj.value
-          : addZero(obj.value, 2),
-      );
-    }
-    return durations.join(":");
+    const durations = this.getFormattedDurationArray()
+    const listOfKeys = Object.keys(keyList)
+    return durations.slice(listOfKeys.indexOf(fromT), listOfKeys.indexOf(toT) + 1).join(":");
   }
   /**
    * Get a simple formatted duration in the form dd:hh:mm:ss:ms
    * @returns {string} Formatted string
    */
   getSimpleFormattedDuration(): string {
-    return `${this.array.map((x) => x.value).join(":")}`;
+    return `${this.getFormattedDurationArray().join(":")}`;
+  }
+  getFormattedDurationArray(): string[] {
+    return this.array.map((x) => ["ms", "us", "ns"].includes(x.type) ? addZero(x.value, 3) : addZero(x.value, 2))
   }
   /**
    * Extra filler function that returns the class data in a single short string.

--- a/mod.ts
+++ b/mod.ts
@@ -190,7 +190,13 @@ export class Duration {
     this.ns += n;
     return this.reload();
   }
-
+  /**
+   * Clone current duration (run Duration#reload before this if you manually tweaked the properties).
+   * @returns {Duration} cloned duration
+   */
+  clone(): Duration {
+    return new Duration(this.raw);
+  }
   /**
    * Get a duration formatted using colons (:).
    * @param {string} fromT - Unit to display from.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@retraigo/duration.js",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "type": "module",
   "description": "Get the formatted time duration",
   "main": "mod.js",

--- a/test.js
+++ b/test.js
@@ -1,36 +1,26 @@
-import {Duration} from "./mod.ts";
+import { Duration } from "./mod.js"
 
-/*
-const dur = new Duration(177013); // A random duration
+console.debug(`Testing duration with Normal number`, new Duration(923))
 
-console.log(dur);
-console.log(new Duration(261174).toString());
+console.debug(`Testing duration with 0`, new Duration(0))
 
-console.log(new Duration(165684).stringify());
-console.log(new Duration(165684).stringify(["s", "h"]));
+console.debug(`Testing duration with BigInt`, new Duration(BigInt(923)))
 
-console.log(new Duration(114750).json);
+console.debug(`Testing duration with Negative number`, new Duration(-923))
 
-console.log(new Duration(245074).array);
-const a = new Duration(0)
-console.log(a.setHours(10))
-console.log(a.setMicroseconds(34344334))
-console.log(a.addMinutes(100))
+console.debug(`Starting to test speed...`)
+console.time("Speed Test")
+const a = new Duration(0);
+console.timeLog("Speed Test", "Initiated Duration", "-", `${performance.now()}ms`)
+for(let i = 0; i < 1000000; ++i) {
+    a.addSeconds(1);
+}
+console.timeLog("Speed Test", "Ran addSeconds 1000000 times.", "-", `${performance.now()}ms`)
+const b = a.clone()
+console.timeLog("Speed Test", "Cloned the duration.", "-", `${performance.now()}ms`)
+console.timeEnd("Speed Test", "-", `${performance.now()}ms`)
+console.debug("Stringifying Test:", "Words:", b.stringify())
+console.debug("Stringifying Test:", "Short:", b.stringify([], true));
+console.debug("Stringifying Test:", "Shorter:", b.toString())
 
-
-*/
-
-const a = new Duration(0).setHours(10).setMicroseconds(34344334).addMinutes(100)
-const b = new Duration(0).setHours(13).setMicroseconds(3434344334).addMinutes(160)
-
-console.log(b.raw, a.raw, b.raw - a.raw, b - a, Duration.between(b - a), new Duration(b - a), b > a, a > b)
-
-
-/*
-const d = new Duration(6000.4353262);
-console.log(d.µs)
-d.m += 70;
-console.log(d); // Only d.m changes. d.h remains the same
-d.reload();
-console.log(d); // d.m turns into 10 and d.h turns into 1
-*/
+console.debug("Parsing Test:", JSON.stringify(b))


### PR DESCRIPTION
**Describe your PR:**
- Deprecate `Duration#getSimpleFormattedDuration` in favor of #18.
- Add `Duration#getFormattedDurationArray` to simplify formatting.
- Add `Duration#toJSON`.
- Rewrite `Duration#toString`.
- Add `Duration#clone`.
- Support BigInts.
- Add `Duration#since` as a wrapper for `Duration#between`.
- Write some tests for Node.
- Bump version to `3.1.1`.
- Update readme.